### PR TITLE
changes paths to match refactor, reduces epochs to 1

### DIFF
--- a/regression/main/wandb-git/examples/pytorch-cnn-mnist/regression.yaml
+++ b/regression/main/wandb-git/examples/pytorch-cnn-mnist/regression.yaml
@@ -6,10 +6,12 @@ sources:
         base: examples
         #hash: 
 launch:
-    path: examples/pytorch-cnn-mnist/
+    path: examples/examples/pytorch/pytorch-cnn-mnist/
     command:
         - python
         - main.py
+        - --epochs
+        - 1
 components:
     extra:
         pip:

--- a/regression/main/wandb-git/examples/pytorch-cnn-mnist/wandb-full.patch
+++ b/regression/main/wandb-git/examples/pytorch-cnn-mnist/wandb-full.patch
@@ -1,7 +1,7 @@
-diff --git a/pytorch-cnn-mnist/main.py b/pytorch-cnn-mnist/main.py
+diff --git a/examples/pytorch/pytorch-cnn-mnist/main.py b/examples/pytorch/pytorch-cnn-mnist/main.py
 index bf16956..9010c9d 100644
---- a/pytorch-cnn-mnist/main.py
-+++ b/pytorch-cnn-mnist/main.py
+--- a/examples/pytorch/pytorch-cnn-mnist/main.py
++++ b/examples/pytorch/pytorch-cnn-mnist/main.py
 @@ -6,6 +6,7 @@ import torch.nn.functional as F
  import torch.optim as optim
  from torchvision import datasets, transforms


### PR DESCRIPTION
1. The [`wandb/examples` repo](https://github.com/wandb/examples) has been refactored, so all of the paths need to change. Before doing this for all of the example scripts, I wanted to get a 👍 on the approach. Is there an easier way? If not, I'm going to use a regular expression to change the paths programmatically.
2. For many of these examples, there's the opportunity to run a shorter test: only a single epoch instead of 10, in this case. Is there a good reason not to do so?